### PR TITLE
Add unit tests for org.holer.common.util.HolerConfig

### DIFF
--- a/SourceCode/Java/holer-common/pom.xml
+++ b/SourceCode/Java/holer-common/pom.xml
@@ -33,5 +33,16 @@
             <version>${jackson.version}</version>
         </dependency>
         <!-- jackson end -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.6.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/SourceCode/Java/holer-common/src/test/java/org/holer/common/util/HolerConfigTest.java
+++ b/SourceCode/Java/holer-common/src/test/java/org/holer/common/util/HolerConfigTest.java
@@ -1,0 +1,81 @@
+package org.holer.common.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import java.util.Properties;
+
+@RunWith(PowerMockRunner.class)
+public class HolerConfigTest {
+
+    @Test
+    public void testStrValue1() {
+        Assert.assertEquals("a\'b\'c", new HolerConfig(null)
+                .getConfig(null).strValue("a\'b\'c", "a\'b\'c"));
+    }
+
+    @PrepareForTest(StringUtils.class)
+    @Test
+    public void testStrValue2() throws Exception {
+        HolerConfig holerConfig = new HolerConfig();
+        Properties properties = new Properties();
+        FieldUtils.writeField(holerConfig, "holerConf", properties, true);
+
+        PowerMockito.mockStatic(StringUtils.class);
+        PowerMockito.when(StringUtils.isBlank("foo")).thenReturn(true);
+
+        Assert.assertNull(holerConfig.strValue("foo", "bar"));
+    }
+
+    @PrepareForTest(StringUtils.class)
+    @Test
+    public void testIntValue1() throws Exception {
+        HolerConfig holerConfig = new HolerConfig();
+        Properties properties = new Properties();
+        properties.setProperty("\u0000\u0000", "9");
+        FieldUtils.writeField(holerConfig, "holerConf", properties, true);
+
+        PowerMockito.mockStatic(StringUtils.class);
+        PowerMockito.when(StringUtils.isNumeric("\u0000\u0000")).thenReturn(false);
+
+        Assert.assertEquals(5, holerConfig.intValue("\u0000\u0000", 5));
+    }
+
+    @Test
+    public void testIntValue2() throws Exception {
+        HolerConfig holerConfig = new HolerConfig();
+        Properties properties = new Properties();
+        properties.setProperty("\u0000\u0000", "9");
+        FieldUtils.writeField(holerConfig, "holerConf", properties, true);
+
+        Assert.assertEquals(9, holerConfig.intValue("\u0000\u0000", 9));
+        Assert.assertEquals(3, HolerConfig.getConfig(null).intValue("5", 3));
+    }
+
+    @Test
+    public void testBoolValue1() throws Exception {
+        HolerConfig holerConfig = new HolerConfig();
+        Properties properties = new Properties();
+        properties.setProperty("\u09f2\uf7db\u0830", "false");
+        FieldUtils.writeField(holerConfig, "holerConf", properties, true);
+
+        Assert.assertFalse(holerConfig.boolValue("\u09f2\uf7db\u0830", null));
+
+        Assert.assertTrue(HolerConfig.getConfig().boolValue("false", true));
+    }
+
+    @Test
+    public void testBoolValue2() throws Exception {
+        HolerConfig holerConfig = new HolerConfig();
+        Properties properties = new Properties();
+        properties.setProperty("a/b/c", "BAZ");
+        FieldUtils.writeField(holerConfig, "holerConf", properties, true);
+
+        Assert.assertNull(holerConfig.boolValue("a/b/c"));
+    }
+}

--- a/SourceCode/Java/pom.xml
+++ b/SourceCode/Java/pom.xml
@@ -70,6 +70,14 @@
                     </nonFilteredFileExtensions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
I've analysed your codebase and noticed that `org.holer.common.util.HolerConfig` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important.